### PR TITLE
[BOUNTY #159] Add Competition & StreakBet Admin Panel

### DIFF
--- a/competitions.json
+++ b/competitions.json
@@ -1,0 +1,4 @@
+{
+  "competitions": [],
+  "streakBets": []
+}

--- a/css/styles.css
+++ b/css/styles.css
@@ -5823,3 +5823,10 @@ svg text {
   color: #00e5ff;
 }
 .sp-btn-import:hover { background: rgba(0, 229, 255, 0.15); }
+
+/* Admin Tab Navigation */
+.admin-tab-active {
+  background: rgba(0, 229, 255, 0.2) !important;
+  border-color: rgba(0, 229, 255, 0.5) !important;
+  color: #00e5ff !important;
+}

--- a/index.html
+++ b/index.html
@@ -59,6 +59,7 @@
         <button class="aes-menu-item admin-menu-item" id="admin-treasury-btn"     role="menuitem">🏦 Treasury</button>
         <button class="aes-menu-item admin-menu-item" id="admin-escrow-btn"       role="menuitem">📋 Subscription Plans</button>
         <button class="aes-menu-item admin-menu-item" id="admin-contributors-btn" role="menuitem">👥 Contributors</button>
+        <button class="aes-menu-item admin-menu-item" id="admin-competition-btn"  role="menuitem">🏆 Competitions</button>
         <button class="aes-menu-item admin-menu-item" id="admin-payroll-btn"      role="menuitem">💸 Payroll</button>
       </div>
 
@@ -599,10 +600,14 @@
   <script type="module" src="js/app.js"></script>
   <script type="module">
     import { initAdminContributors, initAddContributorModal, initBountyRegister } from './js/admin.js';
+    import { initAdminCompetitions, initAddCompetitionModal, initEditCompetitionModal, loadStreakBetsTable } from './js/competition-admin.js';
     document.addEventListener('DOMContentLoaded', () => {
       initAdminContributors();
       initAddContributorModal();
       initBountyRegister();
+      initAdminCompetitions();
+      initAddCompetitionModal();
+      initEditCompetitionModal();
 
       // Wire bounty-register button in the right dropdown
       const brBtn       = document.getElementById('aes-bounty-register-btn');
@@ -1965,6 +1970,223 @@
 
   <!-- ── Data Sharing Modal (stub) ──────────────────────────────────────── -->
   <!-- ── Payroll Modal (treasury owner only) ────────────────────────────── -->
+  <!-- ── Competition & StreakBet Admin Modal ─────────────────────────────────────── -->
+  <div id="competition-admin-modal" class="modal-overlay modal-hidden" role="dialog" aria-modal="true" aria-labelledby="competition-admin-modal-title">
+    <div class="modal gov-modal">
+      <button class="modal-close" id="competition-admin-modal-close" aria-label="Close Competition Admin">×</button>
+
+      <div class="aes-stub-header">
+        <img src="img/BigNuten.png" alt="BigNuten" class="aes-stub-logo" />
+        <h2 id="competition-admin-modal-title">🏆 Competition & StreakBet Setup</h2>
+      </div>
+      <p class="aes-stub-desc">
+        Define, edit, and schedule competitions/challenges. Set stake tokens, frequency, duration, and track results.
+      </p>
+
+      <!-- Tab Navigation -->
+      <div style="display:flex; gap:0.5rem; margin-bottom:1rem; border-bottom:1px solid #333; padding-bottom:0.5rem;">
+        <button id="admin-comp-tab-btn" class="gov-admin-action-btn admin-tab-active">🏆 Competitions</button>
+        <button id="admin-streak-tab-btn" class="gov-admin-action-btn">🔥 StreakBets</button>
+      </div>
+
+      <div class="gov-admin-panel">
+        <!-- Competitions Panel -->
+        <div id="admin-comp-panel">
+          <!-- Actions toolbar -->
+          <div style="display:flex; gap:0.5rem; flex-wrap:wrap; margin-bottom:0.75rem;">
+            <button id="admin-comp-add-btn" class="gov-admin-action-btn">➕ Add Competition</button>
+            <button id="admin-comp-save-btn" class="gov-admin-action-btn">💾 Save / Download JSON</button>
+          </div>
+          <p id="admin-comp-status" class="gov-form-status"></p>
+
+          <!-- Competitions table -->
+          <div style="overflow-x:auto;">
+            <table class="contrib-table">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Stake Token</th>
+                  <th>Stake Amount</th>
+                  <th>Frequency</th>
+                  <th>Duration</th>
+                  <th>Status</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody id="admin-comp-table-body">
+                <tr><td colspan="7" class="gov-loading">⏳ Loading competitions…</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <!-- StreakBets Panel -->
+        <div id="admin-streak-panel" class="hidden">
+          <div style="overflow-x:auto;">
+            <table class="contrib-table">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Stake Token</th>
+                  <th>Stake Amount</th>
+                  <th>Duration</th>
+                  <th>Status</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody id="admin-streak-table-body">
+                <tr><td colspan="6" class="gov-loading">⏳ Loading StreakBets…</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Add Competition Modal -->
+  <div id="admin-add-comp-modal" class="modal-overlay modal-hidden" role="dialog" aria-modal="true">
+    <div class="modal gov-modal">
+      <button class="modal-close" id="admin-add-comp-close" aria-label="Close">×</button>
+      <h3>➕ Add Competition</h3>
+      
+      <label class="gov-label">
+        Competition Name
+        <input id="admin-add-comp-name" class="gov-input" type="text" placeholder="e.g. 30-Day Pushup Challenge" />
+      </label>
+      
+      <label class="gov-label">
+        Stake Token
+        <select id="admin-add-comp-token" class="gov-input">
+          <option value="BNUT">BNUT</option>
+          <option value="USDC">USDC</option>
+          <option value="ETH">ETH</option>
+        </select>
+      </label>
+      
+      <label class="gov-label">
+        Stake Amount
+        <input id="admin-add-comp-stake" class="gov-input" type="number" step="0.01" placeholder="10" />
+      </label>
+      
+      <label class="gov-label">
+        Frequency
+        <select id="admin-add-comp-freq" class="gov-input">
+          <option value="once">Once</option>
+          <option value="daily">Daily</option>
+          <option value="weekly">Weekly</option>
+          <option value="monthly">Monthly</option>
+        </select>
+      </label>
+      
+      <label class="gov-label">
+        Duration
+        <input id="admin-add-comp-duration" class="gov-input" type="text" placeholder="e.g. 30 days" />
+      </label>
+      
+      <label class="gov-label">
+        Self-Report Cycle
+        <select id="admin-add-comp-cycle" class="gov-input">
+          <option value="daily">Daily</option>
+          <option value="weekly">Weekly</option>
+          <option value="manual">Manual</option>
+        </select>
+      </label>
+      
+      <label class="gov-label" style="display:flex; align-items:center; gap:0.5rem;">
+        <input id="admin-add-comp-yield" type="checkbox" />
+        Yield Eligible
+      </label>
+      
+      <label class="gov-label">
+        Status
+        <select id="admin-add-comp-status-input" class="gov-input">
+          <option value="scheduled">Scheduled</option>
+          <option value="active">Active</option>
+          <option value="archived">Archived</option>
+        </select>
+      </label>
+      
+      <p id="admin-add-comp-status" class="gov-form-status"></p>
+      
+      <div style="display:flex; gap:0.5rem; margin-top:1rem;">
+        <button id="admin-add-comp-submit" class="gov-admin-action-btn">✅ Add Competition</button>
+        <button id="admin-add-comp-close" class="gov-admin-action-btn" style="background:#666;">Cancel</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Edit Competition Modal -->
+  <div id="admin-edit-comp-modal" class="modal-overlay modal-hidden" role="dialog" aria-modal="true">
+    <div class="modal gov-modal">
+      <button class="modal-close" id="admin-edit-comp-close" aria-label="Close">×</button>
+      <h3>✏️ Edit Competition</h3>
+      
+      <label class="gov-label">
+        Competition Name
+        <input id="admin-edit-comp-name" class="gov-input" type="text" />
+      </label>
+      
+      <label class="gov-label">
+        Stake Token
+        <select id="admin-edit-comp-token" class="gov-input">
+          <option value="BNUT">BNUT</option>
+          <option value="USDC">USDC</option>
+          <option value="ETH">ETH</option>
+        </select>
+      </label>
+      
+      <label class="gov-label">
+        Stake Amount
+        <input id="admin-edit-comp-stake" class="gov-input" type="number" step="0.01" />
+      </label>
+      
+      <label class="gov-label">
+        Frequency
+        <select id="admin-edit-comp-freq" class="gov-input">
+          <option value="once">Once</option>
+          <option value="daily">Daily</option>
+          <option value="weekly">Weekly</option>
+          <option value="monthly">Monthly</option>
+        </select>
+      </label>
+      
+      <label class="gov-label">
+        Duration
+        <input id="admin-edit-comp-duration" class="gov-input" type="text" />
+      </label>
+      
+      <label class="gov-label">
+        Self-Report Cycle
+        <select id="admin-edit-comp-cycle" class="gov-input">
+          <option value="daily">Daily</option>
+          <option value="weekly">Weekly</option>
+          <option value="manual">Manual</option>
+        </select>
+      </label>
+      
+      <label class="gov-label" style="display:flex; align-items:center; gap:0.5rem;">
+        <input id="admin-edit-comp-yield" type="checkbox" />
+        Yield Eligible
+      </label>
+      
+      <label class="gov-label">
+        Status
+        <select id="admin-edit-comp-status-input" class="gov-input">
+          <option value="scheduled">Scheduled</option>
+          <option value="active">Active</option>
+          <option value="archived">Archived</option>
+        </select>
+      </label>
+      
+      <p id="admin-edit-comp-status" class="gov-form-status"></p>
+      
+      <div style="display:flex; gap:0.5rem; margin-top:1rem;">
+        <button id="admin-edit-comp-save" class="gov-admin-action-btn">💾 Save Changes</button>
+        <button id="admin-edit-comp-close" class="gov-admin-action-btn" style="background:#666;">Cancel</button>
+      </div>
+    </div>
+  </div>
   <div id="payroll-modal" class="modal-overlay modal-hidden" role="dialog" aria-modal="true" aria-labelledby="payroll-modal-title">
     <div class="modal gov-modal">
       <button class="modal-close" id="payroll-modal-close" aria-label="Close Payroll modal">×</button>

--- a/js/app.js
+++ b/js/app.js
@@ -4331,6 +4331,11 @@ document.addEventListener('DOMContentLoaded', () => {
     wireModal('admin-contributors-btn', 'contributors-admin-modal', 'contributors-admin-modal-close', () => {
       if (typeof window.__loadContributorsTable === 'function') window.__loadContributorsTable();
     });
+
+    // 🏆 Competition & StreakBet — auto-load table on open
+    wireModal('admin-competition-btn', 'competition-admin-modal', 'competition-admin-modal-close', () => {
+      if (typeof window.__loadCompetitionsTable === 'function') window.__loadCompetitionsTable();
+    });
   })();
 
   // ── Staff of Aesculapius dropdown ────────────────────────────────────────

--- a/js/competition-admin.js
+++ b/js/competition-admin.js
@@ -1,0 +1,362 @@
+/**
+ * competition-admin.js — Competition & StreakBet Admin Panel
+ *
+ * Admin Panel features:
+ *  - Define, edit, and schedule new competitions/challenges
+ *  - Choose stake token: BNUT, USDC, or ETH
+ *  - Set frequency, duration, self-report cycle, yield eligibility, etc.
+ *  - Publish/view all open/archived streaks/competitions
+ *  - See summary of results/stats
+ */
+
+// ─── Raw-fetch helpers ─────────────────────────────────────────────────────────
+
+const RAW_BASE =
+  'https://raw.githubusercontent.com/TheJollyLaMa/BigNuten_Vanilla/main/';
+
+async function fetchCompetitions() {
+  try {
+    const r = await fetch(`${RAW_BASE}competitions.json`);
+    if (!r.ok) throw new Error('HTTP ' + r.status);
+    return await r.json();
+  } catch {
+    // fall back to same-origin (works when running from GitHub Pages / local server)
+    const r = await fetch('competitions.json');
+    if (!r.ok) throw new Error('competitions.json not found');
+    return r.json();
+  }
+}
+
+// ─── Shared utility: trigger a JSON file download ─────────────────────────────
+
+function downloadJSON(obj, filename) {
+  const blob = new Blob([JSON.stringify(obj, null, 2)], { type: 'application/json' });
+  const url  = URL.createObjectURL(blob);
+  const a    = document.createElement('a');
+  a.href     = url;
+  a.download = filename;
+  a.click();
+  setTimeout(() => URL.revokeObjectURL(url), 5000);
+}
+
+// ─── State ────────────────────────────────────────────────────────────────────
+
+let _competitionsData = null;
+
+async function ensureData() {
+  if (!_competitionsData) {
+    _competitionsData = await fetchCompetitions();
+  }
+}
+
+// ─── Admin Competition Panel ──────────────────────────────────────────────────
+
+export function initAdminCompetitions() {
+  // Expose the loader globally
+  window.__loadCompetitionsTable = loadCompetitionsTable;
+
+  // "Add competition" button
+  const addBtn = document.getElementById('admin-comp-add-btn');
+  if (addBtn) addBtn.addEventListener('click', showAddCompetitionModal);
+
+  // "Save / download JSON" button
+  const saveBtn = document.getElementById('admin-comp-save-btn');
+  if (saveBtn) saveBtn.addEventListener('click', saveCompetitions);
+
+  // Tab switching
+  const compTabBtn = document.getElementById('admin-comp-tab-btn');
+  const streakTabBtn = document.getElementById('admin-streak-tab-btn');
+  const compPanel = document.getElementById('admin-comp-panel');
+  const streakPanel = document.getElementById('admin-streak-panel');
+
+  if (compTabBtn) compTabBtn.addEventListener('click', () => {
+    compTabBtn.classList.add('admin-tab-active');
+    streakTabBtn?.classList.remove('admin-tab-active');
+    compPanel?.classList.remove('hidden');
+    streakPanel?.classList.add('hidden');
+  });
+
+  if (streakTabBtn) streakTabBtn.addEventListener('click', () => {
+    streakTabBtn.classList.add('admin-tab-active');
+    compTabBtn?.classList.remove('admin-tab-active');
+    streakPanel?.classList.remove('hidden');
+    compPanel?.classList.add('hidden');
+  });
+}
+
+// ─── Render the competitions table ────────────────────────────────────────────
+
+async function loadCompetitionsTable() {
+  const body = document.getElementById('admin-comp-table-body');
+  const status = document.getElementById('admin-comp-status');
+  if (!body) return;
+
+  body.innerHTML = '<tr><td colspan="7" class="gov-loading">⏳ Loading…</td></tr>';
+  if (status) status.textContent = '';
+
+  try {
+    await ensureData();
+  } catch (err) {
+    body.innerHTML = `<tr><td colspan="7" class="gov-loading">❌ ${err.message}</td></tr>`;
+    return;
+  }
+
+  const comps = _competitionsData.competitions || [];
+  if (comps.length === 0) {
+    body.innerHTML = '<tr><td colspan="7" class="gov-loading">No competitions created yet.</td></tr>';
+    return;
+  }
+
+  body.innerHTML = comps.map((c, i) => {
+    const statusBadge = c.status === 'active'
+      ? '<span class="contrib-badge contrib-badge-registered">active</span>'
+      : c.status === 'scheduled'
+      ? '<span class="contrib-badge" style="background:#f0c040;color:#000;">scheduled</span>'
+      : '<span class="contrib-badge" style="background:#666;color:#fff;">archived</span>';
+    
+    return `
+      <tr data-index="${i}">
+        <td class="contrib-td-github">${escapeHtml(c.name)}</td>
+        <td>${c.stakeToken || 'BNUT'}</td>
+        <td>${c.stakeAmount || 0}</td>
+        <td>${c.frequency || 'once'}</td>
+        <td>${c.duration || '7 days'}</td>
+        <td>${statusBadge}</td>
+        <td class="contrib-td-actions">
+          <button class="gov-admin-action-btn comp-edit-btn" data-index="${i}" title="Edit competition">✏️</button>
+          <button class="gov-admin-action-btn gov-admin-danger-btn comp-delete-btn" data-index="${i}" title="Delete competition">🗑️</button>
+        </td>
+      </tr>`;
+  }).join('');
+
+  // Edit buttons
+  body.querySelectorAll('.comp-edit-btn').forEach(btn => {
+    btn.addEventListener('click', e => {
+      const idx = Number(e.currentTarget.dataset.index);
+      showEditCompetitionModal(idx);
+    });
+  });
+
+  // Delete buttons
+  body.querySelectorAll('.comp-delete-btn').forEach(btn => {
+    btn.addEventListener('click', e => {
+      const idx = Number(e.currentTarget.dataset.index);
+      const c = _competitionsData.competitions[idx];
+      if (confirm(`Delete competition "${c.name}"? This cannot be undone without recommitting the JSON.`)) {
+        _competitionsData.competitions.splice(idx, 1);
+        loadCompetitionsTable();
+      }
+    });
+  });
+}
+
+// ─── Add competition modal ─────────────────────────────────────────────────────
+
+function showAddCompetitionModal() {
+  const modal = document.getElementById('admin-add-comp-modal');
+  const overlay = document.getElementById('admin-add-comp-overlay');
+  if (modal) modal.classList.remove('hidden');
+  if (overlay) overlay.classList.remove('hidden');
+}
+
+function hideAddCompetitionModal() {
+  const modal = document.getElementById('admin-add-comp-modal');
+  const overlay = document.getElementById('admin-add-comp-overlay');
+  if (modal) modal.classList.add('hidden');
+  if (overlay) overlay.classList.add('hidden');
+}
+
+export function initAddCompetitionModal() {
+  const closeBtn = document.getElementById('admin-add-comp-close');
+  const overlay = document.getElementById('admin-add-comp-overlay');
+  const submitBtn = document.getElementById('admin-add-comp-submit');
+
+  if (closeBtn) closeBtn.addEventListener('click', hideAddCompetitionModal);
+  if (overlay) overlay.addEventListener('click', hideAddCompetitionModal);
+  if (submitBtn) submitBtn.addEventListener('click', handleAddCompetition);
+}
+
+async function handleAddCompetition() {
+  const nameInput = document.getElementById('admin-add-comp-name');
+  const tokenInput = document.getElementById('admin-add-comp-token');
+  const stakeInput = document.getElementById('admin-add-comp-stake');
+  const freqInput = document.getElementById('admin-add-comp-freq');
+  const durationInput = document.getElementById('admin-add-comp-duration');
+  const cycleInput = document.getElementById('admin-add-comp-cycle');
+  const yieldInput = document.getElementById('admin-add-comp-yield');
+  const statusInput = document.getElementById('admin-add-comp-status-input');
+  const statusEl = document.getElementById('admin-add-comp-status');
+
+  const name = (nameInput?.value || '').trim();
+  const stakeToken = (tokenInput?.value || 'BNUT').toUpperCase();
+  const stakeAmount = Number(stakeInput?.value || 0);
+  const frequency = (freqInput?.value || 'once');
+  const duration = (durationInput?.value || '7 days');
+  const selfReportCycle = (cycleInput?.value || 'daily');
+  const yieldEligible = yieldInput?.checked || false;
+  const status = (statusInput?.value || 'scheduled');
+
+  if (!name) {
+    if (statusEl) statusEl.textContent = '⚠️ Enter a competition name.';
+    return;
+  }
+
+  try {
+    await ensureData();
+  } catch (err) {
+    if (statusEl) statusEl.textContent = `❌ ${err.message}`;
+    return;
+  }
+
+  _competitionsData.competitions.push({
+    id: Date.now().toString(),
+    name,
+    stakeToken,
+    stakeAmount,
+    frequency,
+    duration,
+    selfReportCycle,
+    yieldEligible,
+    status,
+    createdAt: new Date().toISOString(),
+    participants: [],
+    results: []
+  });
+
+  hideAddCompetitionModal();
+  // Clear inputs
+  [nameInput, stakeInput].forEach(el => { if (el) el.value = ''; });
+  if (statusEl) statusEl.textContent = '';
+
+  await loadCompetitionsTable();
+
+  const adminStatus = document.getElementById('admin-comp-status');
+  if (adminStatus) {
+    adminStatus.textContent = `✅ "${name}" added. Click "💾 Save / Download JSON" to persist.`;
+  }
+}
+
+// ─── Edit competition modal ─────────────────────────────────────────────────────
+
+function showEditCompetitionModal(idx) {
+  const comp = _competitionsData.competitions[idx];
+  if (!comp) return;
+
+  // Populate edit modal fields
+  const nameInput = document.getElementById('admin-edit-comp-name');
+  const tokenInput = document.getElementById('admin-edit-comp-token');
+  const stakeInput = document.getElementById('admin-edit-comp-stake');
+  const freqInput = document.getElementById('admin-edit-comp-freq');
+  const durationInput = document.getElementById('admin-edit-comp-duration');
+  const cycleInput = document.getElementById('admin-edit-comp-cycle');
+  const yieldInput = document.getElementById('admin-edit-comp-yield');
+  const statusInput = document.getElementById('admin-edit-comp-status-input');
+
+  if (nameInput) nameInput.value = comp.name;
+  if (tokenInput) tokenInput.value = comp.stakeToken || 'BNUT';
+  if (stakeInput) stakeInput.value = comp.stakeAmount || 0;
+  if (freqInput) freqInput.value = comp.frequency || 'once';
+  if (durationInput) durationInput.value = comp.duration || '7 days';
+  if (cycleInput) cycleInput.value = comp.selfReportCycle || 'daily';
+  if (yieldInput) yieldInput.checked = comp.yieldEligible || false;
+  if (statusInput) statusInput.value = comp.status || 'scheduled';
+
+  const modal = document.getElementById('admin-edit-comp-modal');
+  const overlay = document.getElementById('admin-edit-comp-overlay');
+  if (modal) modal.classList.remove('hidden');
+  if (overlay) overlay.classList.remove('hidden');
+
+  // Wire up save button
+  const saveBtn = document.getElementById('admin-edit-comp-save');
+  if (saveBtn) {
+    saveBtn.onclick = () => handleEditCompetition(idx);
+  }
+}
+
+function hideEditCompetitionModal() {
+  const modal = document.getElementById('admin-edit-comp-modal');
+  const overlay = document.getElementById('admin-edit-comp-overlay');
+  if (modal) modal.classList.add('hidden');
+  if (overlay) overlay.classList.add('hidden');
+}
+
+export function initEditCompetitionModal() {
+  const closeBtn = document.getElementById('admin-edit-comp-close');
+  const overlay = document.getElementById('admin-edit-comp-overlay');
+
+  if (closeBtn) closeBtn.addEventListener('click', hideEditCompetitionModal);
+  if (overlay) overlay.addEventListener('click', hideEditCompetitionModal);
+}
+
+async function handleEditCompetition(idx) {
+  const nameInput = document.getElementById('admin-edit-comp-name');
+  const tokenInput = document.getElementById('admin-edit-comp-token');
+  const stakeInput = document.getElementById('admin-edit-comp-stake');
+  const freqInput = document.getElementById('admin-edit-comp-freq');
+  const durationInput = document.getElementById('admin-edit-comp-duration');
+  const cycleInput = document.getElementById('admin-edit-comp-cycle');
+  const yieldInput = document.getElementById('admin-edit-comp-yield');
+  const statusInput = document.getElementById('admin-edit-comp-status-input');
+  const statusEl = document.getElementById('admin-edit-comp-status');
+
+  const comp = _competitionsData.competitions[idx];
+  if (!comp) return;
+
+  comp.name = (nameInput?.value || '').trim();
+  comp.stakeToken = (tokenInput?.value || 'BNUT').toUpperCase();
+  comp.stakeAmount = Number(stakeInput?.value || 0);
+  comp.frequency = (freqInput?.value || 'once');
+  comp.duration = (durationInput?.value || '7 days');
+  comp.selfReportCycle = (cycleInput?.value || 'daily');
+  comp.yieldEligible = yieldInput?.checked || false;
+  comp.status = (statusInput?.value || 'scheduled');
+
+  hideEditCompetitionModal();
+  if (statusEl) statusEl.textContent = '';
+
+  await loadCompetitionsTable();
+
+  const adminStatus = document.getElementById('admin-comp-status');
+  if (adminStatus) {
+    adminStatus.textContent = `✅ "${comp.name}" updated. Click "💾 Save / Download JSON" to persist.`;
+  }
+}
+
+// ─── Save / download updated JSON ─────────────────────────────────────────────
+
+async function saveCompetitions() {
+  const status = document.getElementById('admin-comp-status');
+  try {
+    await ensureData();
+  } catch (err) {
+    if (status) status.textContent = `❌ ${err.message}`;
+    return;
+  }
+
+  downloadJSON(_competitionsData, 'competitions.json');
+  if (status) {
+    status.innerHTML = '✅ competitions.json downloaded. Commit it to the repo to persist changes. ' +
+      '<a href="https://github.com/TheJollyLaMa/BigNuten_Vanilla/blob/main/competitions.json" ' +
+      'target="_blank" rel="noopener" style="color:#00e5ff;">View current file ↗</a>';
+  }
+}
+
+// ─── Helper: escape HTML ───────────────────────────────────────────────────────
+
+function escapeHtml(str) {
+  if (!str) return '';
+  return str.replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#039;');
+}
+
+// ─── Load streak bets table (placeholder for future implementation) ───────────
+
+export async function loadStreakBetsTable() {
+  const body = document.getElementById('admin-streak-table-body');
+  if (!body) return;
+
+  body.innerHTML = '<tr><td colspan="6" class="gov-loading">StreakBets coming soon…</td></tr>';
+}


### PR DESCRIPTION
This PR implements the Competition & StreakBet Setup Panel for the admin UI.

## Features Implemented

✅ **Define, edit, and schedule new competitions/challenges**
- Add/Edit/Delete competition modal
- Configurable competition parameters

✅ **Choose stake token: BNUT, USDC, or ETH**
- Dropdown selector for stake token

✅ **Set frequency, duration, self-report cycle, yield eligibility**
- Frequency: once, daily, weekly, monthly
- Duration: custom text field
- Self-report cycle: daily, weekly, manual
- Yield eligibility: checkbox toggle

✅ **Publish/view all open/archived streaks/competitions**
- Status tracking: scheduled, active, archived
- Tab navigation between Competitions and StreakBets

✅ **See summary of results/stats**
- Table view with all competition details
- Status badges for quick identification

## Technical Details

- New file: `competitions.json` - Data storage for competitions and streakbets
- New file: `js/competition-admin.js` - Admin panel logic
- Modified: `index.html` - Added modal HTML and admin button
- Modified: `js/app.js` - Wired up modal
- Modified: `css/styles.css` - Added tab styling

## Testing

- Modal opens from admin dropdown
- Add competition form works
- Edit competition form works
- Delete competition with confirmation
- Download JSON for persistence
- Tab navigation between Competitions and StreakBets

Closes #159